### PR TITLE
Python setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+import site, sys, setuptools
+
+if __name__ == '__main__':
+    # https://github.com/pypa/pip/issues/7953#issuecomment-645133255
+    site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
+    setuptools.setup()


### PR DESCRIPTION
Add a *setup.py* such that even pip of an old version can work ([reference](https://stackoverflow.com/questions/46205648/can-pip-install-from-setup-cfg-as-if-installing-from-a-requirements-file)).  See issue #38 .