### PR TITLE
Reorganize init.py into functions with fewer side effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ In this example, we use the Julia module PythonCall from a [Pluto](https://githu
 
 ## Example 2: Calling Julia from Python
 
+### Changes in jlapeyre branches !
+
+The examples have not been updated to reflect the following. In order to use the Python module JuliaCall (juliacall),
+you must do
+```python
+import juliacall
+juliacall.default_init()
+```
+
 In this example we use the Python module JuliaCall from an IPython notebook to train a simple neural network:
 - We generate some random training data using Python's Numpy.
 - We construct and train a neural network model using Julia's Flux.

--- a/juliacall/__init__.py
+++ b/juliacall/__init__.py
@@ -1,4 +1,7 @@
 __version__ = '0.5.1'
 CONFIG = dict(embedded=False)
 from .all import *
-from . import init
+
+# In application code, use `juliacall.default_init()`
+#from . import init
+from .init import default_init


### PR DESCRIPTION
This PR reorganizes most of the code in `init.py` into functions. I also reduced the use of globals/side-effects so that the required order of function calls is more clear.

A single, important, API change is also made. Rather than `import juliacall` doing all of the work of initializing Julia, you need to do this
```python
import juliacall
juliacall.default_init()
```

 [This](https://github.com/jlapeyre/PythonCall.jl/blob/1a5727d5ea5fa7c3c001978f33a45d082b281480/juliacall/init.py#L207-L226) is the initialization function
```python
def default_init():
    """
    Initialize Julia and its packages.
    After importing `juliacall`, call this method initialize the Julia
    dependencies. This includes first locating the julia executable and library,
    and if none is found, downloading a Julia distribution. Then the required
    Julia packages are installed.
    """
    # Are we developing PythonCall
    isdev = find_isdev()
    # Determine paths to mutable data maintained by PythonCall, and julia
    jlenv, jlprefix, meta_path = find_env_paths()
    # Determine whether or not to skip resolving julia/package versions
    skip = deps.can_skip_resolve(isdev, meta_path)
    # Find a compatible jula executable and libjulia
    libpath = find_julia_library(skip, jlprefix)
    # Initialze libjulia
    lib = init_libjulia(libpath)
    install_packages(lib, skip, isdev, jlenv, meta_path)
```

Part of the value is just in cleaning up the code: making data function-local, passing parameters rather than using global data, reducing the scope of a `try` block, etc.

The reason for delaying the initialization is that it gives a package author much more flexibility in designing a python package that depends on Julia (or even in a personal workflow) to meet particular needs.  So with this PR, one can immediately write a package-specific version of `default_init` and with a bit (or more) of code:

* pass a custom system image.
* Issue a prompt before downloading Julia.
* Use jill.py or juliaup to download Julia or search for the appropriate version.
* Things we don't know about, but someone else has in mind.

For example I am very interested in trying `juliacall` in [`julia_project`](https://github.com/jlapeyre/julia_project). This PR would make it much easier to integrate `juliacall` in such projects.