### PR TITLE
crop whitespace around displayed figures

### DIFF
--- a/src/compat/multimedia.jl
+++ b/src/compat/multimedia.jl
@@ -106,7 +106,7 @@ function pyshow_rule_savefig(io::IO, mime::String, x::Py)
             fig = fig.figure
         end
         buf = pyimport("io").BytesIO()
-        x.savefig(buf, format=format)
+        x.savefig(buf, format=format, bbox_inches="tight")
         data = @pyconvert(Vector{UInt8}, buf.getvalue(), return false)
         write(io, data)
         plt.close(fig)


### PR DESCRIPTION
This matches what PyPlot is [doing](https://github.com/JuliaPy/PyPlot.jl/blob/94366fcfd783e4467b9dae789c12a9762c87dcf3/src/PyPlot.jl#L100) too. 