### PR TITLE
define 2-arg Base.hash

### DIFF
--- a/src/Py.jl
+++ b/src/Py.jl
@@ -366,7 +366,7 @@ end
 
 Base.in(v, x::Py) = pycontains(x, v)
 
-Base.hash(x::Py) = reinterpret(UInt, Int(pyhash(x)))
+Base.hash(x::Py, h::UInt) = reinterpret(UInt, Int(pyhash(x))) - 3h
 
 (f::Py)(args...; kwargs...) = pycall(f, args...; kwargs...)
 


### PR DESCRIPTION
If you only define the 1-argument `hash(o::Py)`, then the 2-argument form `hash(o, h::UInt)` falls back to the generic `Base` method using `objectid(o)`, which is not what you want.

(Subtracting `- 3h` is what `Base.hash` typically does to mix hashes; I'm not sure if you want to do something fancier here?)