### PR TITLE
correct Julia minimum version to ≥ 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ MacroTools = "0.5"
 Requires = "1"
 Tables = "1"
 UnsafePointers = "1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
Your `Project.toml` currently lists `julia = "1"`, but in my testing it seems that it requires Julia 1.6+ (and [your CI tests](https://github.com/cjdoris/PythonCall.jl/blob/b4528b71e9878c8a71b9bd48ff759b5d5b14267f/.github/workflows/tests.yml#L19) also require 1.6+).

In particular, you depend on MicroMamba.jl, which [also requires Julia 1.6+](https://github.com/cjdoris/MicroMamba.jl/blob/5f5c49780a0ae449becedc139be1c3ab244cec03/Project.toml#L12).   But if you try to install PythonCall on an earlier Julia version, it just pulls in an earlier version of MicroMamba (before [this commit](https://github.com/cjdoris/MicroMamba.jl/commit/51389e6ca4845f30c46bfe743d1b896caf6de6da)).

On earlier versions of Julia, I get errors like:
```jl
julia> using PythonCall
[ Info: Precompiling PythonCall [6099a3de-0909-46bc-b1f4-468b9a2dfc0d]
    CondaPkg Found dependencies: /Users/stevenj/.julia/packages/PythonCall/B5irB/CondaPkg.toml
  MicroMamba Downloading: https://micro.mamba.pm/api/micromamba/osx-64/latest
  MicroMamba Installing: /Users/stevenj/.julia/scratchspaces/0b3b1443-0f03-428d-bdfb-f27f9c1191ea/install/micromamba
ERROR: InitError: /Users/stevenj/.julia/scratchspaces/0b3b1443-0f03-428d-bdfb-f27f9c1191ea/install/micromamba does not seem to be a MicroMamba executable
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] executable(; io::Base.TTY) at /Users/stevenj/.julia/packages/MicroMamba/lsDkG/src/MicroMamba.jl:127
 [3] cmd(; io::Base.TTY) at /Users/stevenj/.julia/packages/MicroMamba/lsDkG/src/MicroMamba.jl:202
 [4] #cmd#13 at /Users/stevenj/.julia/packages/MicroMamba/lsDkG/src/MicroMamba.jl:209 [inlined]
 [5] _resolve_conda_create(::Base.TTY, ::String, ::Array{CondaPkg.PkgSpec,1}, ::Array{String,1}) at /Users/stevenj/.julia/packages/CondaPkg/qEpDY/src/CondaPkg.jl:281
 [6] resolve(; force::Bool, io::Base.TTY) at /Users/stevenj/.julia/packages/CondaPkg/qEpDY/src/CondaPkg.jl:375
 [7] resolve() at /Users/stevenj/.julia/packages/CondaPkg/qEpDY/src/CondaPkg.jl:327
 [8] envdir at /Users/stevenj/.julia/packages/CondaPkg/qEpDY/src/CondaPkg.jl:482 [inlined]
 [9] init_context() at /Users/stevenj/.julia/packages/PythonCall/B5irB/src/cpython/context.jl:54
 [10] __init__() at /Users/stevenj/.julia/packages/PythonCall/B5irB/src/cpython/CPython.jl:20
 [11] _include_from_serialized(::String, ::Array{Any,1}) at ./loading.jl:697
 [12] _require_from_serialized(::String) at ./loading.jl:749
 [13] _require(::Base.PkgId) at ./loading.jl:1040
 [14] require(::Base.PkgId) at ./loading.jl:928
 [15] require(::Module, ::Symbol) at ./loading.jl:923
```
