### PR TITLE
fix relative JULIA_PROJECT

### DIFF
--- a/python/juliacall/__init__.py
+++ b/python/juliacall/__init__.py
@@ -57,7 +57,7 @@ def init():
 
     # Find the Julia executable and project
     CONFIG['exepath'] = exepath = juliapkg.executable()
-    CONFIG['project'] = project = juliapkg.project()
+    CONFIG['project'] = project = os.path.abspath(juliapkg.project())
 
     # Find the Julia library
     cmd = [exepath, '--project='+project, '--startup-file=no', '-O0', '--compile=min', '-e', 'import Libdl; print(abspath(Libdl.dlpath("libjulia")))']


### PR DESCRIPTION
Previously this would fail if e.g. `JULIA_PROJECT=.` because of the chdir just  below.