### PR TITLE
Fix minor bug in `Utils.is{c,f}contiguous`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PythonCall"
 uuid = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 authors = ["Christopher Doris <github.com/cjdoris>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -161,8 +161,12 @@ module Utils
     size_to_fstrides(elsz::Integer, sz::Tuple{Vararg{Integer}}) =
         isempty(sz) ? () : (elsz, size_to_fstrides(elsz * sz[1], sz[2:end])...)
 
+    size_to_fstrides(elsz::Integer, sz::Vararg{Integer}) = size_to_fstrides(elsz, sz)
+
     size_to_cstrides(elsz::Integer, sz::Tuple{Vararg{Integer}}) =
         isempty(sz) ? () : (size_to_cstrides(elsz * sz[end], sz[1:end-1])..., elsz)
+
+    size_to_cstrides(elsz::Integer, sz::Vararg{Integer}) = size_to_cstrides(elsz, sz)
 
     isfcontiguous(o::AbstractArray) = strides(o) == size_to_fstrides(1, size(o)...)
     isccontiguous(o::AbstractArray) = strides(o) == size_to_cstrides(1, size(o)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,9 @@ using PythonCall, Test, Dates, Aqua
 Aqua.test_all(PythonCall, unbound_args=false)
 
 @testset "PythonCall.jl" begin
+    @testset "utils" begin
+        include("utils.jl")
+    end
     @testset "abstract" begin
         include("abstract.jl")
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,23 @@
+using PythonCall.Utils: size_to_fstrides, size_to_cstrides, isfcontiguous, isccontiguous
+
+@testset "strides" begin
+    @test size_to_fstrides(1, (2, 3, 4)) == (1, 2, 6)
+    @test size_to_fstrides(1, 2, 3, 4) == (1, 2, 6)
+    @test size_to_cstrides(1, (2, 3, 4)) == (12, 4, 1)
+    @test size_to_cstrides(1, 2, 3, 4) == (12, 4, 1)
+
+    # A plain old Julia array should be Fortran-continuous.
+    a = zeros(2, 3, 4)
+    @test isfcontiguous(a)
+    @test !isccontiguous(a)
+
+    # But if we reverse the dimensions it should be C-continuous.
+    a_perm = PermutedDimsArray(a, (3, 2, 1))
+    @test !isfcontiguous(a_perm)
+    @test isccontiguous(a_perm)
+
+    # And if we do something crazy it will be neither.
+    a_crazy = PermutedDimsArray(a, (2, 3, 1))
+    @test !isfcontiguous(a_crazy)
+    @test !isccontiguous(a_crazy)
+end


### PR DESCRIPTION
PythonCall.jl is awesome!

I was curious if NumPy arrays passed to Julia were C-contiguous or Fortran-contiguous, and ran into a minor bug in `Utils.isccontiguous` and `Utils.isfcontiguous`. Fixed it, added some tests.