### PR TITLE
fix: Ensure julia lib is always loaded as global

### DIFF
--- a/pysrc/juliacall/__init__.py
+++ b/pysrc/juliacall/__init__.py
@@ -118,7 +118,7 @@ def init():
     try:
         # Open the library
         os.chdir(os.path.dirname(libpath))
-        CONFIG['lib'] = lib = c.CDLL(libpath, c.RTLD_GLOBAL)
+        CONFIG['lib'] = lib = c.CDLL(libpath, mode=c.RTLD_GLOBAL)
         lib.jl_init__threading.argtypes = []
         lib.jl_init__threading.restype = None
         lib.jl_init__threading()

--- a/pysrc/juliacall/__init__.py
+++ b/pysrc/juliacall/__init__.py
@@ -118,7 +118,7 @@ def init():
     try:
         # Open the library
         os.chdir(os.path.dirname(libpath))
-        CONFIG['lib'] = lib = c.CDLL(libpath)
+        CONFIG['lib'] = lib = c.CDLL(libpath, c.RTLD_GLOBAL)
         lib.jl_init__threading.argtypes = []
         lib.jl_init__threading.restype = None
         lib.jl_init__threading()


### PR DESCRIPTION
From issue https://github.com/cjdoris/PythonCall.jl/issues/175 some users have noticed that there is an issue with running the Juliacall python module on Apple.

Investigating the issue was found that the julia library load was causing the error.

From my report and thanks to the Julia community they pointed out that the library should be loaded in RTLD_GLOBAL mode (https://github.com/JuliaLang/julia/issues/45709)