### PR TITLE
fix deprecation and possible faulty construction of pandas tables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PythonCall"
 uuid = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 authors = ["Christopher Doris <github.com/cjdoris>"]
-version = "0.9.7"
+version = "0.9.6"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PythonCall"
 uuid = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 authors = ["Christopher Doris <github.com/cjdoris>"]
-version = "0.9.6"
+version = "0.9.7"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"

--- a/src/pywrap/PyPandasDataFrame.jl
+++ b/src/pywrap/PyPandasDataFrame.jl
@@ -102,6 +102,6 @@ function _columns(df, columnnames, columntypes)
     # output a table
     # TODO: realising columns to vectors could be done lazily with a different table type
     schema = Tables.Schema(colnames, coltypes)
-    coldict = Dict(k=>v for (k,v) in zip(colnames, columns))
+    coldict = Tables.OrderedDict(k=>v for (k,v) in zip(colnames, columns))
     Tables.DictColumnTable(schema, coldict)
 end


### PR DESCRIPTION
Before this PR pandas tables were being constructed from `Tables.DictColumnTable` using an unordered dict for the columns.  This was leading to deprecation warnings [as seen here](https://github.com/JuliaData/Tables.jl/issues/294#issue-1364917637) but more importantly, it could result in the creation of table objects which would have content inconsistent with their schema.  I'm actually a bit unsure why this was not breaking far more spectacularly (**update:** it's because the methods provided by `DictColumnTable` make the ordering of the dict largely unnecessary, but it would still break if anything ever iterated over the columns in the dict.)

I used the `OrderedDict` constructor from within `Tables` for this so as not to have to add `OrderedCollections` as a dependency.