### PR TITLE
libstdcxx version-bounds

### DIFF
--- a/docs/src/pythoncall.md
+++ b/docs/src/pythoncall.md
@@ -285,6 +285,24 @@ into it. If you want to use a pre-existing Conda environment, see the previous s
 If `conda`, `mamba` or `micromamba` is not in your `PATH` you will also need to set
 `JULIA_CONDAPKG_EXE` to its path.
 
+#### If you installed a newer version of libstdc++
+On Linux, Julia comes bundled with its own copy of *libstdc++*.  Therefore, when interacting with
+CondaPkg, PythonCall injects a dependency to bound the allowed versions of the `libstdcxx-ng`
+Conda package. To override this value (e.g. if the user replaced the bundled libstdc++ with something
+newer), use:
+
+```julia
+[PythonCall]
+ENV["JULIA_CONDAPKG_LIBSTDCXX_VERSION_BOUND"] = ">=3.4,<=12"
+```
+
+To figure out installed version, run
+```bash
+strings /path/to/julia/lib/julia/libstdc++.so.6 | grep GLIBCXX
+```
+Then look at <https://gcc.gnu.org/onlinedocs/gcc-12.1.0/libstdc++/manual/manual/abi.html>
+for the GCC version compatible with the GLIBCXX version.
+
 ## [Installing Python packages](@id python-deps)
 
 Assuming you haven't [opted out](@ref pythoncall-config), PythonCall uses

--- a/docs/src/pythoncall.md
+++ b/docs/src/pythoncall.md
@@ -292,7 +292,7 @@ override this value, use:
 
 ```julia
 [PythonCall]
-ENV["JULIA_CONDAPKG_LIBSTDCXX_VERSION_BOUND"] = ">=3.4,<=12"
+ENV["JULIA_PYTHONCALL_LIBSTDCXX_VERSION_BOUND"] = ">=3.4,<=12"
 ```
 
 To figure out installed version, run

--- a/docs/src/pythoncall.md
+++ b/docs/src/pythoncall.md
@@ -286,10 +286,10 @@ If `conda`, `mamba` or `micromamba` is not in your `PATH` you will also need to 
 `JULIA_CONDAPKG_EXE` to its path.
 
 #### If you installed a newer version of libstdc++
-On Linux, Julia comes bundled with its own copy of *libstdc++*.  Therefore, when interacting with
-CondaPkg, PythonCall injects a dependency to bound the allowed versions of the `libstdcxx-ng`
-Conda package. To override this value (e.g. if the user replaced the bundled libstdc++ with something
-newer), use:
+PythonCall injects a dependency to bound the allowed versions of the `libstdcxx-ng`
+Conda package. It finds the bound by runtime discovery of the libstdcxx version.  To
+override this value (e.g. if the user replaced the bundled libstdc++ with something
+else, use:
 
 ```julia
 [PythonCall]

--- a/docs/src/pythoncall.md
+++ b/docs/src/pythoncall.md
@@ -288,8 +288,7 @@ If `conda`, `mamba` or `micromamba` is not in your `PATH` you will also need to 
 #### If you installed a newer version of libstdc++
 PythonCall injects a dependency to bound the allowed versions of the `libstdcxx-ng`
 Conda package. It finds the bound by runtime discovery of the libstdcxx version.  To
-override this value (e.g. if the user replaced the bundled libstdc++ with something
-else, use:
+override this value, use:
 
 ```julia
 [PythonCall]

--- a/docs/src/pythoncall.md
+++ b/docs/src/pythoncall.md
@@ -287,7 +287,7 @@ If `conda`, `mamba` or `micromamba` is not in your `PATH` you will also need to 
 
 #### If you installed a newer version of libstdc++
 PythonCall injects a dependency to bound the allowed versions of the `libstdcxx-ng`
-Conda package. It finds the bound by runtime discovery of the libstdcxx version.  To
+Conda package. It finds the bound by runtime discovery of the libstdc++ version.  To
 override this value, use:
 
 ```julia

--- a/src/cpython/context.jl
+++ b/src/cpython/context.jl
@@ -112,7 +112,7 @@ function init_context()
                     if cxx_version !== nothing
                         CondaPkg.add("libstdcxx-ng", version=cxx_version, channel="conda-forge", temp=true, file=joinpath(@__DIR__, "..", "..", "CondaPkg.toml"), resolve=false)
                     end
-                    # if cxx_version is nothing, then we assume that Julia does not link against libstdcxx-ng, and so we do not
+                    # if cxx_version is nothing, then we assume that Julia does not link against any version ob libstdc++ known by Julia, and so we do not
                     # enforce a version bound.
                 end
                 # By default, we use Python installed by CondaPkg.

--- a/src/cpython/context.jl
+++ b/src/cpython/context.jl
@@ -67,7 +67,7 @@ function get_libstdcxx_version_bound()
     # the highest GCC version we know about, which should be a fairly safe choice.
     max_version = get(vers_mapping, loaded_libstdcxx_version.patch, vers_mapping[maximum(keys(vers_mapping))])
     cxx_version = ">=3.4,<=$(max_version.major).$(max_version.minor)"
-    get(ENV, "JULIA_CONDAPKG_LIBSTDCXX_VERSION_BOUND", cxx_version)
+    get(ENV, "JULIA_PYTHONCALL_LIBSTDCXX_VERSION_BOUND", cxx_version)
 end
 
 function init_context()

--- a/src/cpython/context.jl
+++ b/src/cpython/context.jl
@@ -49,6 +49,7 @@ function get_libstdcxx_version_bound()
     vers_mapping = Dict(
         18 => v"4.8.0",
         19 => v"4.8.3",
+        20 => v"4.9.0",
         21 => v"5.1.0",
         22 => v"6.1.0",
         23 => v"7.1.0",
@@ -56,9 +57,9 @@ function get_libstdcxx_version_bound()
         25 => v"8.1.0",
         26 => v"9.1.0",
         27 => v"9.2.0",
-        28 => v"9.3.0",
-        29 => v"11.1.0",
-        30 => v"12.1.0",
+        28 => v"9.5.0",
+        29 => v"11.3.0",
+        30 => v"12.2.0",
         31 => v"13.1.0",
     )
     # Get the libstdcxx version that is currently loaded in this Julia process

--- a/src/cpython/context.jl
+++ b/src/cpython/context.jl
@@ -30,6 +30,31 @@ function _atpyexit()
     return
 end
 
+# By default, ensure libstdc++ in the Conda environment is compatible with
+# the one linked in Julia. This is platform/version dependent, so needs to
+# occur at runtime.
+#
+# Allow the user to override the default.  This is useful when the version
+# of libstdcxx linked in Julia is customized in the local installation of
+# Julia.
+#
+# To figure out cxx_version for a given Julia version, run
+#   strings /path/to/julia/lib/julia/libstdc++.so.6 | grep GLIBCXX
+# then look at
+#   https://gcc.gnu.org/onlinedocs/gcc-12.1.0/libstdc++/manual/manual/abi.html
+# for the highest GCC version compatible with the highest GLIBCXX version.
+function get_libstdcxx_version_bound()
+    if Base.VERSION <= v"1.6.2"
+        # GLIBCXX_3.4.26
+        cxx_version = ">=3.4,<9.2"
+    else
+        # GLIBCXX_3.4.29
+        # checked up to v1.8.0
+        cxx_version = ">=3.4,<11.4"
+    end
+    get(ENV, "JULIA_CONDAPKG_LIBSTDCXX_VERSION_BOUND", cxx_version)
+end
+
 function init_context()
 
     CTX.is_embedded = haskey(ENV, "JULIA_PYTHONCALL_LIBPTR")
@@ -60,23 +85,7 @@ function init_context()
                 exe_path::String
             else
                 if Sys.islinux()
-                    # Ensure libstdc++ in the Conda environment is compatible with the one
-                    # linked in Julia. This is platform/version dependent, so needs to occur at
-                    # runtime.
-                    #
-                    # To figure out cxx_version for a given Julia version, run
-                    #   strings /path/to/julia/lib/julia/libstdc++.so.6 | grep GLIBCXX
-                    # then look at
-                    #   https://gcc.gnu.org/onlinedocs/gcc-12.1.0/libstdc++/manual/manual/abi.html
-                    # for the highest GCC version compatible with the highest GLIBCXX version.
-                    if Base.VERSION <= v"1.6.2"
-                        # GLIBCXX_3.4.26
-                        cxx_version = ">=3.4,<9.2"
-                    else
-                        # GLIBCXX_3.4.29
-                        # checked up to v1.8.0
-                        cxx_version = ">=3.4,<11.4"
-                    end
+                    cxx_version = get_libstdcxx_version_bound()
                     CondaPkg.add("libstdcxx-ng", version=cxx_version, channel="conda-forge", temp=true, file=joinpath(@__DIR__, "..", "..", "CondaPkg.toml"), resolve=false)
                 end
                 # By default, we use Python installed by CondaPkg.

--- a/test/context.jl
+++ b/test/context.jl
@@ -1,0 +1,14 @@
+@testitem "libstdc++ version" begin
+    cxxversion = PythonCall.get_libstdcxx_version_bound()
+
+    if VERSION <= v"1.6.2"
+        @test cxxversion == ">=3.4,<9.2"
+    else
+        @test cxxversion == ">=3.4,<11.4"
+    end
+
+    ENV["JULIA_CONDAPKG_LIBSTDCXX_VERSION_BOUND"] = ">=3.4,<=12"
+
+    cxxversion = PythonCall.get_libstdcxx_version_bound()
+    @test cxxversion == ">3.4,<=12"
+end

--- a/test/context.jl
+++ b/test/context.jl
@@ -1,5 +1,5 @@
 @testitem "libstdc++ version" begin
-    ENV["JULIA_CONDAPKG_LIBSTDCXX_VERSION_BOUND"] = ">=3.4,<=12"
+    ENV["JULIA_PYTHONCALL_LIBSTDCXX_VERSION_BOUND"] = ">=3.4,<=12"
 
     cxxversion = PythonCall.C.get_libstdcxx_version_bound()
     @test cxxversion == ">=3.4,<=12"

--- a/test/context.jl
+++ b/test/context.jl
@@ -1,14 +1,6 @@
 @testitem "libstdc++ version" begin
-    cxxversion = PythonCall.get_libstdcxx_version_bound()
-
-    if VERSION <= v"1.6.2"
-        @test cxxversion == ">=3.4,<9.2"
-    else
-        @test cxxversion == ">=3.4,<11.4"
-    end
-
     ENV["JULIA_CONDAPKG_LIBSTDCXX_VERSION_BOUND"] = ">=3.4,<=12"
 
-    cxxversion = PythonCall.get_libstdcxx_version_bound()
-    @test cxxversion == ">3.4,<=12"
+    cxxversion = PythonCall.C.get_libstdcxx_version_bound()
+    @test cxxversion == ">=3.4,<=12"
 end


### PR DESCRIPTION
Hello,

We have run into a problem when using PythonCall with newer versions of TensorFlow.  In particular, TensorFlow requires newer versions of libstdc++ than what is bundled with Julia.  To partially solve this problem, we replace the bundled version of libstdc++ with the system (Ubuntu 22.04) version of libstdc++.

When using PythonCall and CondaPkg, PythonCall injects a version bound for libstdc++ into the conda operations.  The version bound is determined by the version of libstdc++ bundled in Julia.  In this PR, we find the bound at runtime, and allow the user to specify the version bound via an environment variable: ~`JULIA_CONDAPKG_LIBSTDCXX_VERSION_BOUND`~`JULIA_PYTHONCALL_LIBSTDCXX_VERSION_BOUND`.  For example, set the version bound via:
```julia
ENV["JULIA_PYTHONCALL_LIBSTDCXX_VERSION_BOUND"] = ">=3.4,<=12"
```

Many thanks!

Fixes #237 
