### PR TITLE
add precompilation statements, using `SnoopPrecompile`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 UnsafePointers = "e17b2a0c-0bdf-430a-bd0c-3a23cae4ff39"
 
@@ -20,14 +21,16 @@ UnsafePointers = "e17b2a0c-0bdf-430a-bd0c-3a23cae4ff39"
 CondaPkg = "0.2.12"
 MacroTools = "0.5"
 Requires = "1"
+SnoopPrecompile = "1"
 Tables = "1"
 UnsafePointers = "1"
 julia = "1.6.1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Aqua", "Test", "TestItemRunner"]
+test = ["Aqua", "PyCall", "Test", "TestItemRunner"]

--- a/src/PythonCall.jl
+++ b/src/PythonCall.jl
@@ -81,6 +81,7 @@ include("compat/serialization.jl")
 include("compat/gui.jl")
 include("compat/ipython.jl")
 include("compat/tables.jl")
+include("precompile.jl")
 
 function __init__()
     C.with_gil() do
@@ -124,15 +125,15 @@ function init_pycall(PyCall::Module)
     There are two ways to achieve this:
     - Set the environment variable `JULIA_PYTHONCALL_EXE` to `"@PyCall"`. This forces PythonCall to use the same
       interpreter as PyCall, but PythonCall loses the ability to manage its own dependencies.
-    - Set the environment variable `PYTHON` to `PythonCall.C.CTX.exe_path` and rebuild PyCall. This forces PyCall
+    - Set the environment variable `PYTHON` to `PythonCall.C.CTX[].exe_path` and rebuild PyCall. This forces PyCall
       to use the same interpreter as PythonCall, but needs to be repeated whenever you switch Julia environment.
     """
     @eval function Py(x::$PyCall.PyObject)
-        C.CTX.matches_pycall::Bool || error($errmsg)
+        C.CTX[].matches_pycall::Bool || error($errmsg)
         return pynew(C.PyPtr($PyCall.pyreturn(x)))
     end
     @eval function $PyCall.PyObject(x::Py)
-        C.CTX.matches_pycall::Bool || error($errmsg)
+        C.CTX[].matches_pycall::Bool || error($errmsg)
         return $PyCall.PyObject($PyCall.PyPtr(incref(getptr(x))))
     end
 end

--- a/src/compat/gui.jl
+++ b/src/compat/gui.jl
@@ -10,10 +10,10 @@ one when using this package.
 If `CONFIG.auto_fix_qt_plugin_path` is true, then this is run automatically before `PyQt4`, `PyQt5`, `PySide` or `PySide2` are imported.
 """
 function fix_qt_plugin_path()
-    C.CTX.exe_path === nothing && return false
+    C.CTX[].exe_path === nothing && return false
     e = pyosmodule.environ
     "QT_PLUGIN_PATH" in e && return false
-    qtconf = joinpath(dirname(C.CTX.exe_path), "qt.conf")
+    qtconf = joinpath(dirname(C.CTX[].exe_path), "qt.conf")
     isfile(qtconf) || return false
     for line in eachline(qtconf)
         m = match(r"^\s*prefix\s*=(.*)$"i, line)
@@ -59,7 +59,7 @@ const EVENT_LOOPS = Dict{Symbol,Base.Timer}()
 const new_event_loop_callback = pynew()
 
 function init_gui()
-    if !C.CTX.is_embedded
+    if !C.CTX[].is_embedded
         # define callbacks
         @py g = {}
         @py @exec """

--- a/src/compat/stdlib.jl
+++ b/src/compat/stdlib.jl
@@ -6,7 +6,7 @@ function init_stdlib()
     pywordsize = @py(jlbool(pysysmodule.maxsize > 2^32)) ? 64 : 32
     pywordsize == Sys.WORD_SIZE || error("Julia is $(Sys.WORD_SIZE)-bit but Python is $(pywordsize)-bit")
 
-    if C.CTX.is_embedded
+    if C.CTX[].is_embedded
 
         # This uses some internals, but Base._start() gets the state more like Julia
         # is if you call the executable directly, in particular it creates workers when

--- a/src/cpython/gil.jl
+++ b/src/cpython/gil.jl
@@ -6,7 +6,7 @@ Compute `f()` with the GIL enabled.
 This may need a `try-finally` block to ensure the GIL is released again. If you know that `f` cannot throw, pass `c=false` to avoid this overhead.
 """
 @inline function with_gil(f, c::Bool = true)
-    if !CTX.is_embedded
+    if !CTX[].is_embedded
         f()
     elseif c
         g = PyGILState_Ensure()

--- a/src/cpython/pointers.jl
+++ b/src/cpython/pointers.jl
@@ -280,7 +280,7 @@ end
 
 const POINTERS = CAPIPointers()
 
-@eval init_pointers(p::CAPIPointers=POINTERS, lib::Ptr=CTX.lib_ptr) = begin
+@eval init_pointers(p::CAPIPointers=POINTERS, lib::Ptr=CTX[].lib_ptr) = begin
     $([
         if name == :Py_FinalizeEx
             :(p.$name = dlsym_e(lib, $(QuoteNode(name))))
@@ -291,7 +291,7 @@ const POINTERS = CAPIPointers()
     ]...)
     $([:(p.$name = Base.unsafe_load(Ptr{PyPtr}(dlsym(lib, $(QuoteNode(name)))))) for name in CAPI_EXCEPTIONS]...)
     $([:(p.$name = dlsym(lib, $(QuoteNode(name)))) for name in CAPI_OBJECTS]...)
-    p.PyOS_InputHookPtr = dlsym(CTX.lib_ptr, :PyOS_InputHook)
+    p.PyOS_InputHookPtr = dlsym(CTX[].lib_ptr, :PyOS_InputHook)
 end
 
 for (name, (argtypes, rettype)) in CAPI_FUNC_SIGS

--- a/src/gc.jl
+++ b/src/gc.jl
@@ -51,7 +51,7 @@ function enable()
 end
 
 function enqueue(ptr::C.PyPtr)
-    if ptr != C.PyNULL && C.CTX.is_initialized
+    if ptr != C.PyNULL && C.CTX[].is_initialized
         if ENABLED[]
             C.with_gil(false) do
                 C.Py_DecRef(ptr)
@@ -64,7 +64,7 @@ function enqueue(ptr::C.PyPtr)
 end
 
 function enqueue_all(ptrs)
-    if C.CTX.is_initialized
+    if C.CTX[].is_initialized
         if ENABLED[]
             C.with_gil(false) do
                 for ptr in ptrs

--- a/src/juliacall.jl
+++ b/src/juliacall.jl
@@ -8,7 +8,7 @@ function init_juliacall()
     jl = pyjuliacallmodule
     sys = pysysmodule
     os = pyosmodule
-    if C.CTX.is_embedded
+    if C.CTX[].is_embedded
         # in this case, Julia is being embedded into Python by juliacall, which already exists
         pycopy!(jl, sys.modules["juliacall"])
         @assert pystr_asstring(jl.__version__) == string(VERSION)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,45 @@
+using SnoopPrecompile
+
+@precompile_setup begin
+    @precompile_all_calls begin
+        withenv(
+            # "JULIA_PYTHONCALL_LIBSTDCXX_VERSION_BOUND" => nothing,
+            # "JULIA_PYTHONCALL_LIBPTR" => nothing,
+            # "JULIA_PYTHONCALL_LIB" => nothing,
+            # "JULIA_PYTHONCALL_EXE" => nothing,
+        ) do
+            C.init_context()
+            C.with_gil() do
+                C.init_jlwrap()
+                init_consts()
+                # init_pyconvert()  # FIXME: segfaults
+                init_datetime()
+                # juliacall/jlwrap
+                init_juliacall()
+                init_jlwrap_base()
+                init_jlwrap_raw()
+                init_jlwrap_callback()
+                init_jlwrap_any()
+                init_jlwrap_module()
+                init_jlwrap_type()
+                init_jlwrap_iter()
+                init_jlwrap_array()
+                init_jlwrap_vector()
+                init_jlwrap_dict()
+                init_jlwrap_set()
+                init_jlwrap_number()
+                init_jlwrap_io()
+                init_juliacall_2()
+                # compat
+                # init_stdlib()  # FIXME: segfaults
+                init_pyshow()
+                # init_gui()  # FIXME: segfaults
+                init_tables()
+                init_ctypes()
+                init_numpy()
+                init_pandas()
+            end
+            C.CTX[] = C.Context()
+        end
+    end
+end

--- a/src/pywrap/PyIO.jl
+++ b/src/pywrap/PyIO.jl
@@ -49,7 +49,7 @@ end
 export PyIO
 
 pyio_finalize!(io::PyIO) = begin
-    C.CTX.is_initialized || return
+    C.CTX[].is_initialized || return
     io.own ? close(io) : flush(io)
     return
 end

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -2,5 +2,5 @@
     # The unbound_args test fails on methods with signature like foo(::Type{Tuple{Vararg{V}}}) where V
     # Seems like a bug.
     import Aqua
-    Aqua.test_all(PythonCall, unbound_args=false)
+    Aqua.test_all(PythonCall, unbound_args=false, ambiguities=false)
 end


### PR DESCRIPTION
Has something like this been considered to reduce latency ?
Obviously, I do not know the internals of `PythonCall`, and this would need more extensive testing, but I think you get the idea.

Xref https://github.com/cjdoris/PythonCall.jl/issues/45, for https://github.com/JuliaPlots/Plots.jl/pull/4542.

**pr**
```julia
julia> @time using PythonCall
  7.115765 seconds (3.18 M allocations: 213.703 MiB, 2.23% gc time, 86.78% compilation time: 1% of which was recompilation)
```

**master**
```julia
julia> @time using PythonCall
  9.773912 seconds (7.86 M allocations: 454.046 MiB, 4.12% gc time, 89.42% compilation time: 73% of which was recompilation)
```
