### PR TITLE
Skip __init__ when precompiling

### DIFF
--- a/src/PythonCall.jl
+++ b/src/PythonCall.jl
@@ -83,6 +83,8 @@ include("compat/ipython.jl")
 include("compat/tables.jl")
 
 function __init__()
+    ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
+
     C.with_gil() do
         init_consts()
         init_pyconvert()

--- a/src/cpython/CPython.jl
+++ b/src/cpython/CPython.jl
@@ -18,6 +18,8 @@ include("gil.jl")
 include("jlwrap.jl")
 
 function __init__()
+    ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
+
     init_context()
     with_gil() do
         init_jlwrap()


### PR DESCRIPTION
I thought `__init__()` was always skipped when precompiling, but this appears to not be the case (at least on Windows). This appears to fix https://github.com/stillyslalom/PyThermo.jl/issues/7, and may also fix https://github.com/cjdoris/PythonCall.jl/issues/266, https://github.com/JuliaPy/PythonPlot.jl/issues/25, and https://github.com/JuliaPy/PythonPlot.jl/issues/27.