### PR TITLE
print caught exceptions when (de)serializing

### DIFF
--- a/src/cpython/jlwrap.jl
+++ b/src/cpython/jlwrap.jl
@@ -205,10 +205,13 @@ function _pyjl_serialize(self::PyPtr, ::PyPtr)
         b = take!(io)
         return PyBytes_FromStringAndSize(pointer(b), sizeof(b))
     catch e
-        PyErr_SetString(
-            POINTERS.PyExc_Exception,
-            "error serializing this value. Caught exception $(sprint(showerror, e, catch_backtrace()))"
-        )
+        PyErr_SetString(POINTERS.PyExc_Exception, "error serializing this value")
+        # wrap sprint in another try-catch block to prevent this function from throwing
+        try
+            @debug "Caught exception $(sprint(showerror, e, catch_backtrace()))"
+        catch e2
+            @debug "Error printing exception: $e2"
+        end
         return PyNULL
     end
 end
@@ -223,10 +226,13 @@ function _pyjl_deserialize(t::PyPtr, v::PyPtr)
         x = deserialize(io)
         return PyJuliaValue_New(t, x)
     catch e
-        PyErr_SetString(
-            POINTERS.PyExc_Exception,
-            "error deserializing this value. Caught exception $(sprint(showerror, e, catch_backtrace()))"
-        )
+        PyErr_SetString(POINTERS.PyExc_Exception, "error deserializing this value")
+        # wrap sprint in another try-catch block to prevent this function from throwing
+        try
+            @debug "Caught exception $(sprint(showerror, e, catch_backtrace()))"
+        catch e2
+            @debug "Error printing exception: $e2"
+        end
         return PyNULL
     end
 end

--- a/src/cpython/jlwrap.jl
+++ b/src/cpython/jlwrap.jl
@@ -205,7 +205,10 @@ function _pyjl_serialize(self::PyPtr, ::PyPtr)
         b = take!(io)
         return PyBytes_FromStringAndSize(pointer(b), sizeof(b))
     catch e
-        PyErr_SetString(POINTERS.PyExc_Exception, "error serializing this value")
+        PyErr_SetString(
+            POINTERS.PyExc_Exception,
+            "error serializing this value. Caught exception $e"
+        )
         return PyNULL
     end
 end
@@ -220,7 +223,10 @@ function _pyjl_deserialize(t::PyPtr, v::PyPtr)
         x = deserialize(io)
         return PyJuliaValue_New(t, x)
     catch e
-        PyErr_SetString(POINTERS.PyExc_Exception, "error deserializing this value")
+        PyErr_SetString(
+            POINTERS.PyExc_Exception,
+            "error deserializing this value. Caught exception $e"
+        )
         return PyNULL
     end
 end

--- a/src/cpython/jlwrap.jl
+++ b/src/cpython/jlwrap.jl
@@ -225,7 +225,7 @@ function _pyjl_deserialize(t::PyPtr, v::PyPtr)
     catch e
         PyErr_SetString(
             POINTERS.PyExc_Exception,
-            "error deserializing this value. Caught exception $e"
+            "error deserializing this value. Caught exception $(sprint(showerror, e. catch_backtrace()))"
         )
         return PyNULL
     end

--- a/src/cpython/jlwrap.jl
+++ b/src/cpython/jlwrap.jl
@@ -207,7 +207,7 @@ function _pyjl_serialize(self::PyPtr, ::PyPtr)
     catch e
         PyErr_SetString(
             POINTERS.PyExc_Exception,
-            "error serializing this value. Caught exception $(sprint(showerror, e. catch_backtrace()))"
+            "error serializing this value. Caught exception $(sprint(showerror, e, catch_backtrace()))"
         )
         return PyNULL
     end
@@ -225,7 +225,7 @@ function _pyjl_deserialize(t::PyPtr, v::PyPtr)
     catch e
         PyErr_SetString(
             POINTERS.PyExc_Exception,
-            "error deserializing this value. Caught exception $(sprint(showerror, e. catch_backtrace()))"
+            "error deserializing this value. Caught exception $(sprint(showerror, e, catch_backtrace()))"
         )
         return PyNULL
     end

--- a/src/cpython/jlwrap.jl
+++ b/src/cpython/jlwrap.jl
@@ -207,7 +207,7 @@ function _pyjl_serialize(self::PyPtr, ::PyPtr)
     catch e
         PyErr_SetString(
             POINTERS.PyExc_Exception,
-            "error serializing this value. Caught exception $e"
+            "error serializing this value. Caught exception $(sprint(showerror, e. catch_backtrace()))"
         )
         return PyNULL
     end


### PR DESCRIPTION
The `caught` exception can useful for tracking down sources of bugs, as was the case for myself earlier today.