### PR TITLE
allow user to configure opt_handle_signals

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -9,6 +9,11 @@ Some rules if you are writing multithreaded code:
 - You probably also need to call `PythonCall.GC.disable()` on the main thread before any
   threaded block of code. Remember to call `PythonCall.GC.enable()` again afterwards.
   (This is because Julia finalizers can be called from any thread.)
+- Julia intentionally causes segmentation faults as part of the GC safepoint mechanism.
+  If unhandled, these segfaults will result in termination of the process. To enable signal handling,
+  set `PYTHON_JULIACALL_HANDLE_SIGNALS=yes` before any calls to import juliacall. This is equivalent
+  to starting julia with `julia --handle-signals=yes`, the default behavior in Julia. 
+  See discussion [here](https://github.com/cjdoris/PythonCall.jl/issues/219#issuecomment-1605087024) for more information.
 - You may still encounter problems.
 
 Related issues: [#201](https://github.com/cjdoris/PythonCall.jl/issues/201), [#202](https://github.com/cjdoris/PythonCall.jl/issues/202)

--- a/pysrc/juliacall/__init__.py
+++ b/pysrc/juliacall/__init__.py
@@ -129,7 +129,7 @@ def init():
     CONFIG['opt_sysimage'] = sysimg = path_option('sysimage', check_exists=True)[0]
     CONFIG['opt_threads'] = int_option('threads', accept_auto=True)[0]
     CONFIG['opt_warn_overwrite'] = choice('warn_overwrite', ['yes', 'no'])[0]
-    CONFIG["opt_handle_signals"] = choice('handle_signals', ['yes', 'no'], default='no')[0]
+    CONFIG['opt_handle_signals'] = choice('handle_signals', ['yes', 'no'], default='no')[0]
 
     # Stop if we already initialised
     if CONFIG['inited']:

--- a/pysrc/juliacall/__init__.py
+++ b/pysrc/juliacall/__init__.py
@@ -129,7 +129,7 @@ def init():
     CONFIG['opt_sysimage'] = sysimg = path_option('sysimage', check_exists=True)[0]
     CONFIG['opt_threads'] = int_option('threads', accept_auto=True)[0]
     CONFIG['opt_warn_overwrite'] = choice('warn_overwrite', ['yes', 'no'])[0]
-    CONFIG['opt_handle_signals'] = 'no'
+    CONFIG["opt_handle_signals"] = choice('handle_signals', ['yes', 'no'], default='no')[0]
 
     # Stop if we already initialised
     if CONFIG['inited']:


### PR DESCRIPTION
Hi @cjdoris , this PR is to allow a user to configure what is passed to `julia --handle-signals=<yes,no>`. I have just updated it to be in line with all the other CONFIG params, defaulting to `no` to retain backwards compatibility. 

Following discussion thread starting [here](https://github.com/cjdoris/PythonCall.jl/issues/219#issuecomment-1605087024), I have found that this is much more robust and clean way to allow for multi-threaded julia code than [my previous workaround](https://github.com/cjdoris/PythonCall.jl/issues/298#issuecomment-1589784428).

Related to #219 
Related to #298 
Related to #330 
