### PR TITLE
qualify `Core` module

### DIFF
--- a/src/Compat/gui.jl
+++ b/src/Compat/gui.jl
@@ -159,7 +159,7 @@ function init_gui()
 
         # add a hook to automatically call fix_qt_plugin_path()
         fixqthook =
-            Py(() -> (Core.CONFIG.auto_fix_qt_plugin_path && fix_qt_plugin_path(); nothing))
+            Py(() -> (PythonCall.Core.CONFIG.auto_fix_qt_plugin_path && fix_qt_plugin_path(); nothing))
         pymodulehooks.add_hook("PyQt4", fixqthook)
         pymodulehooks.add_hook("PyQt5", fixqthook)
         pymodulehooks.add_hook("PySide", fixqthook)


### PR DESCRIPTION
```julia
ERROR: LoadError: InitError: Python: Julia: UndefVarError: `Core` not defined in `PythonCall.Compat`
Hint: It looks like two or more modules export different bindings with this name, resulting in ambiguity. Try explicitly importing it from a particular module, or qualifying the name with the module it should come from.
Hint: a global variable of this name also exists in Core.
Stacktrace:
  [1] (::PythonCall.Compat.var"#1#2")()
    @ PythonCall.Compat [...]/.julia/packages/PythonCall/mkWc2/src/Compat/gui.jl:162
```

Qualify explicitly the `Core` module to avoid `LoadError`.