### PR TITLE
docs: Add python block usage examples

### DIFF
--- a/docs/src/pythoncall.md
+++ b/docs/src/pythoncall.md
@@ -97,40 +97,45 @@ A common use case is calling multiple blocks of Python code from Julia interacti
 
 ```julia-repl
 julia> @pyexec """
-       global re
-       import re
+           global re
+           import re
 
-       def my_sentence(s):
-           words = re.findall("[a-zA-Z]+", s)
-           sentence = " ".join(words)
-           return sentence
-       """ => my_sentence
+           def my_sentence(s):
+               words = re.findall("[a-zA-Z]+", s)
+               sentence = " ".join(words)
+               return sentence
+           """ => my_sentence
 Python: <function my_sentence at 0x7d83bb1b01a0>
 
 julia> sentence = my_sentence("PythonCall.jl is very useful!")
 Python: 'PythonCall jl is very useful'
 ```
 
-Note the use of the `global` keyword to make the `re` package accessible in global scope, and the `=> my_sentence` syntax to create a Julia function named `my_sentence` that calls to the Python function of the same name. This syntax also supports calling to multiple functions:
+Note the use of the `global` keyword to make the `re` package accessible in global scope, and the `=> my_sentence` syntax to create a Julia function named `my_sentence` that calls to the Python function of the same name. This syntax also supports calling to multiple functions and passing data back-and-forth:
 
 ```julia-repl
-julia> @pyexec """
-       def add(a, b):
-         return a + b
+julia> @pyexec (num=10) => """
+           def add(a, b):
+             return a + b
 
-       def subtract(a, b):
-           return a - b
-       """ => (add, subtract)
-(add = <py function add at 0x7e6cbe398d50>, subtract = <py function subtract at 0x7e6cbdfa7b60>)
+           def subtract(a, b):
+               return a - b
+
+           plusone = num + 1
+           """ => (add, subtract, plusone::Float64)
+(add = <py function add at 0x721b001a7cc0>, subtract = <py function subtract at 0x721b001a7d70>, plusone = 11.0)
 
 julia> add(4, 3)
 Python: 7
 
 julia> subtract(4, 3)
 Python: 1
+
+julia> plusone
+11.0
 ```
 
-See [@pyexec](@ref), [@pyeval](@ref), and their functional forms [pyexec](@ref) and [pyeval](@ref), for more.
+Here we demonstrate passing a named variable, `num`, via the use of the `=>` syntax again, and returning named output, with the last element, `plusone`, being cast to a Julia object via the `::` syntax. See [@pyexec](@ref), [@pyeval](@ref), and their functional forms [pyexec](@ref) and [pyeval](@ref), for more.
 
 ## Conversion between Julia and Python
 


### PR DESCRIPTION
Following up from [the discussion here](https://discourse.julialang.org/t/how-to-use-pythoncall-with-string-literal/132907), added some brief usage examples for calling blocks of Python code interactively