### PR TITLE
Specialize pyarray_offset to be more amenable to constprop

### DIFF
--- a/src/Wrap/PyArray.jl
+++ b/src/Wrap/PyArray.jl
@@ -669,6 +669,10 @@ end
     x
 end
 
+# Specialization for the common case where T == R, we can use the
+# constant-propagatable sizeof instead of looking up the stride.
+pyarray_offset(x::PyArray{T,N,M,true,T}, i::Int) where {T,N,M} =
+    N == 0 ? 0 : (i - 1) * sizeof(T)
 pyarray_offset(x::PyArray{T,N,M,true}, i::Int) where {T,N,M} =
     N == 0 ? 0 : (i - 1) * x.strides[1]
 pyarray_offset(x::PyArray{T,1,M,true}, i::Int) where {T,M} = (i - 1) .* x.strides[1]


### PR DESCRIPTION
This improves performance in tight loops, for me it pretty much fixes the performance hit compared to Array (https://github.com/JuliaPy/PythonCall.jl/issues/182#issuecomment-3300603397):
```julia
x_py = PyArray(np.random.rand(1000, 1000).T);
x = Array(x_py);

@benchmark sum($x)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  122.804 μs … 440.813 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     124.024 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   125.858 μs ±   6.590 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▂▆██▆▃▁        ▁     ▁▁▁▁▂▁▁▂▁▁                               ▂
  ██████████▇▇▆▆▇██▇▇█████████████████▇▇▇▆▆▇▆▆▆▆▄▅▅▆▅▄▄▅▄▅▄▅▂▅▅ █
  123 μs        Histogram: log(frequency) by time        146 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

@benchmark sum($x_py)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  128.664 μs … 447.404 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     129.694 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   131.126 μs ±   4.813 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▁▆██▆▂▁                            ▁▁▁▁▁▁▁▁▁                 ▂
  ▃████████▇▆▆▅▅▆▆▅▅▅▆▄▅▇█▇▅▃▄▄▆▆▇▇█████████████████▇▇█▇▇▇▇▆▆▆▆ █
  129 μs        Histogram: log(frequency) by time        143 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.