### PR TITLE
Implement Base.IndexStyle for PyObjectArray using a type argument

### DIFF
--- a/src/JlWrap/objectarray.jl
+++ b/src/JlWrap/objectarray.jl
@@ -10,7 +10,7 @@ PyObjectArray(x::AbstractArray{T,N}) where {T,N} = PyObjectArray{N}(x)
 
 pyobjectarray_finalizer(x::PyObjectArray) = GC.enqueue_all(x.ptrs)
 
-Base.IndexStyle(x::PyObjectArray) = Base.IndexStyle(x.ptrs)
+Base.IndexStyle(T::Type{<: PyObjectArray}) = Base.IndexStyle(fieldtype(T, :ptrs))
 
 Base.length(x::PyObjectArray) = length(x.ptrs)
 

--- a/src/NumpyDates/InlineTimeDelta64.jl
+++ b/src/NumpyDates/InlineTimeDelta64.jl
@@ -24,8 +24,6 @@ end
 
 # accessors
 
-Dates.value(d::InlineTimeDelta64) = d.value
-
 unitpair(::InlineTimeDelta64{U}) where {U} = unitpair(U)
 unitpair(::Type{InlineTimeDelta64{U}}) where {U} = unitpair(U)
 

--- a/src/NumpyDates/TimeDelta64.jl
+++ b/src/NumpyDates/TimeDelta64.jl
@@ -23,8 +23,6 @@ end
 
 # accessors
 
-Dates.value(d::TimeDelta64) = d.value
-
 unitpair(d::TimeDelta64) = d.unit
 
 # constructors


### PR DESCRIPTION
Base already defines a IndexStyle(::AbstractArray) method for object arguments that uses the object type, so we can implement that directly and avoid the invalidations from implement Base.IndexStyle(::PyObjectArray). Fixes these invalidations:
```julia
 inserting IndexStyle(x::PythonCall.PyObjectArray) @ PythonCall.JlWrap ~/.julia/dev/PythonCall/src/JlWrap/objectarray.jl:13 invalidated:                                                                                                       
   backedges: 1: superseding IndexStyle(A::AbstractArray) @ Base indices.jl:94 with MethodInstance for IndexStyle(::AbstractArray) (132 children) 
```