### PR TITLE
Fix arguments for `ArrayValue.__array__()`

### DIFF
--- a/src/JlWrap/array.jl
+++ b/src/JlWrap/array.jl
@@ -357,8 +357,14 @@ function init_array()
                     # convert to an array-like object
                     arr = self
                     if not (hasattr(arr, "__array_interface__") or hasattr(arr, "__array_struct__")):
-                        # the second attempt collects into a PyObjectArray
-                        arr = self._jl_callmethod($(pyjl_methodnum(pyjlarray_array__pyobjectarray)))
+                        if copy is False:
+                            raise ValueError("copy=False is not supported when collecting ArrayValue data")
+                        # the first attempt collects into an Array
+                        arr = self._jl_callmethod($(pyjl_methodnum(pyjlarray_array__array)))
+                        if not (hasattr(arr, "__array_interface__") or hasattr(arr, "__array_struct__")):
+                            # the second attempt collects into a PyObjectArray
+                            arr = self._jl_callmethod($(pyjl_methodnum(pyjlarray_array__pyobjectarray)))
+
                     # convert to a numpy array if numpy is available
                     try:
                         import numpy
@@ -369,7 +375,7 @@ function init_array()
                         major_version = int(numpy.__version__.split(".")[0])
                         if major_version < 2 and copy is None:
                             copy = False
-                        return numpy.array(arr, dtype=dtype, copy=copy)
+                        arr = numpy.array(arr, dtype=dtype, copy=copy)
                     return arr
                 def to_numpy(self, dtype=None, copy=True, order="K"):
                     import numpy


### PR DESCRIPTION
Not sure how but this was broken on the v1 branch. Maybe from a rebase mistake?