### PR TITLE
add CHANGELOG.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .CondaPkg/
 /jltest.*
 uv.lock
+docs/src/releasenotes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release Notes
+# Changelog
 
 ## Unreleased
 * Minimum supported Python version is now 3.10.
@@ -6,6 +6,7 @@
 * Showing `Py` now respects the `compact` option - output is limited to a single line of
   at most the display width.
 * Support policy now documented in the FAQ.
+* Added this changelog (was previously at `docs/src/releasenotes.md`).
 * Bug fixes.
 
 ## 0.9.28 (2025-09-17)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,11 @@ using Documenter, PythonCall
 
 include("customdocs.jl")
 
+# include the changelog in the docs (called release notes there)
+changelog = read("CHANGELOG.md", String)
+changelog = replace(changelog, "# Changelog" => "# Release Notes")
+write("docs/src/releasenotes.md", changelog)
+
 makedocs(
     sitename = "PythonCall & JuliaCall",
     modules = [PythonCall],


### PR DESCRIPTION
Moves `docs/src/releasenotes.md` to `CHANGELOG.md` for better discovery.