### PR TITLE
Adds tests (and fixes) for the dtype invariant.

### DIFF
--- a/docs/src/juliacall-reference.md
+++ b/docs/src/juliacall-reference.md
@@ -202,9 +202,9 @@ jl.Vector[jl.Int]()
 ```
 
 Some Julia types can be converted to corresponding numpy dtypes like `numpy.dtype(jl.Int)`.
-Supports primitive types: `Bool`, `IntXX`, `UIntXX`, `FloatXX`, `ComplexFXX`,
-`NumpyDates.InlineDateTime64{unit}` and `NumpyDates.InlineTimeDelta64{unit}`. Also
-supports tuples, named tuples and structs of these.
+Supports `Bool`, `IntXX`, `UIntXX`, `FloatXX`, `ComplexFXX`,
+`NumpyDates.InlineDateTime64{unit}` and `NumpyDates.InlineTimeDelta64{unit}`, plus
+`Tuple`s and `NamedTuple`s of these.
 `````
 
 `````@customdoc

--- a/src/JlWrap/array.jl
+++ b/src/JlWrap/array.jl
@@ -187,7 +187,7 @@ pybufferformat(::Type{T}) where {T} =
         T == Complex{Cdouble} ? "Zd" :
         T == Bool ? "?" :
         T == Ptr{Cvoid} ? "P" :
-        if isstructtype(T) && isconcretetype(T) && allocatedinline(T)
+        if (T <: Union{Tuple,NamedTuple}) && isstructtype(T) && isconcretetype(T) && allocatedinline(T)
             n = fieldcount(T)
             flds = []
             for i = 1:n
@@ -234,7 +234,7 @@ pyjlarray_isarrayabletype(::Type{NamedTuple{names,types}}) where {names,types} =
 
 const PYTYPESTRDESCR = IdDict{Type,Tuple{String,Py}}()
 
-pytypestrdescr(::Type{T}) where {T} =
+function pytypestrdescr(::Type{T}) where {T}
     get!(PYTYPESTRDESCR, T) do
         c = Utils.islittleendian() ? '<' : '>'
         if T == Bool
@@ -275,7 +275,7 @@ pytypestrdescr(::Type{T}) where {T} =
                 u == NumpyDates.UNBOUND_UNITS ? "" :
                 m == 1 ? "[$(Symbol(u))]" : "[$(m)$(Symbol(u))]"
             ("$(c)$(tc)8$(us)", PyNULL)
-        elseif isstructtype(T) && isconcretetype(T) && Base.allocatedinline(T)
+        elseif (T <: Union{Tuple,NamedTuple}) && isstructtype(T) && isconcretetype(T) && Base.allocatedinline(T)
             n = fieldcount(T)
             flds = []
             for i = 1:n
@@ -298,6 +298,7 @@ pytypestrdescr(::Type{T}) where {T} =
             ("", PyNULL)
         end
     end
+end
 
 pyjlarray_array__array(x::AbstractArray) = x isa Array ? Py(nothing) : pyjl(Array(x))
 pyjlarray_array__pyobjectarray(x::AbstractArray) = pyjl(PyObjectArray(x))


### PR DESCRIPTION
That is, np.array(array).dtype == np.dtype(eltype(array)).

For this to hold, we needed to restrict to only creating dtypes for primitives, tuples and named tuples. We removed support for arbitrary structs (which are not supported by our implementation of the array interface and buffer protocol).

We also worked around a feature/bug/quirk of numpy in that if you do numpy.dtype(descr) where descr is a list of (name,type) field descriptors of a struct, then the dtype you get is not the same as the dtype of an array constructed from something whose array interface has that same descr. In particular, if any item in descr is struct padding like ("", "|V4"), then on conversion to a dtype the name is replaced with e.g. "f2". Going the array route, the padding gets ignored and does not feature in the resulting dtype. The fix here is to compute a different representation of the same information for the dtype - namely the dict of names, types and offsets way.