### PR TITLE
Convert JuliaError.__str__ to python error (on branch v1)

### DIFF
--- a/pysrc/juliacall/__init__.py
+++ b/pysrc/juliacall/__init__.py
@@ -27,9 +27,9 @@ class JuliaError(Exception):
         e = self.exception
         b = self.backtrace
         if b is None:
-            return Base.sprint(Base.showerror, e)
+            return Base.sprint(Base.showerror, e).jl_to_py()
         else:
-            return Base.sprint(Base.showerror, e, b)
+            return Base.sprint(Base.showerror, e, b).jl_to_py()
     @property
     def exception(self):
         return self.args[0]


### PR DESCRIPTION
Strangely, this works fine from PythonCall.jl unit tests... :
```python
try:
    import juliacall
    from juliacall import JuliaError

    juliacall.Main.error()
except JuliaError as e:
    print(e)
```
..but causes this on my project where I'm migrating to v1:
```python
    jl.fail()
../../../.julia/packages/PythonCall/xZbVY/src/JlWrap/any.jl:479: in __call__
    return self._jl_callmethod($(pyjl_methodnum(pyjlany_call)), args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   juliacall.JuliaError: <exception str() failed>

During handling of the above exception, another exception occurred:
test/julia/test_jl.py:25: in test_pyjlvalues
    print(e)
E   TypeError: __str__ returned non-string (type Jl)
```

However, I guess it makes sense to convert to python string.