### PR TITLE
Support baking PythonCall into a juliacall system image (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+* Support baking `PythonCall` into a juliacall system image via the new opt-in
+  `embedded` preference / `JULIA_PYTHONCALL_EMBEDDED` option, removing the
+  `using PythonCall` cost from cold start. No behaviour change unless opted in.
 * Added option `lib` to JuliaCall. Setting this will skip the discovery subprocess.
 * Bug fixes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Changelog
 
 ## Unreleased
-* Support baking `PythonCall` into a juliacall system image via the new opt-in
-  `embedded` preference / `JULIA_PYTHONCALL_EMBEDDED` option, removing the
-  `using PythonCall` cost from cold start. No behaviour change unless opted in.
+* Support baking `PythonCall` into a juliacall system image via
+  `PythonCall._is_embedded[] = true` in a PackageCompiler `script=`.
 * Added option `lib` to JuliaCall. Setting this will skip the discovery subprocess.
 * Bug fixes.
 

--- a/docs/src/juliacall.md
+++ b/docs/src/juliacall.md
@@ -115,6 +115,26 @@ systems that may be readonly. Note that the project set in
 `PYTHON_JULIACALL_PROJECT` *must* already have PythonCall.jl installed and it
 *must* match the JuliaCall version, otherwise loading Julia will fail.
 
+### Baking PythonCall into a system image
+
+For the fastest possible startup you can compile `PythonCall` itself (alongside
+your own packages) into a system image with
+[PackageCompiler.jl](https://github.com/JuliaLang/PackageCompiler.jl), so that
+the `using PythonCall` performed at startup is a memory-map rather than a load.
+
+When `PythonCall` is baked into the system image its `__init__` runs *during*
+`jl_init_with_image`, before juliacall's bootstrap has defined the
+`Main.__PythonCall_libptr` global it normally uses to detect that it is
+embedded. To support this, set the `embedded` preference (or the
+`JULIA_PYTHONCALL_EMBEDDED=yes` environment variable) together with the `lib`
+preference / `JULIA_PYTHONCALL_LIB` pointing at the running interpreter's
+libpython. With `embedded` set, PythonCall takes the embedded path even without
+the global and opens libpython by path (it is already loaded in the process, so
+this is just a handle). The default is `no`, leaving normal behaviour
+unchanged. Use this together with `PYTHON_JULIACALL_SYSIMAGE` (below), and
+`PYTHON_JULIACALL_EXE` / `PYTHON_JULIACALL_PROJECT` so juliacall resolves the
+baked environment directly.
+
 ## [Configuration](@id julia-config)
 
 Some features of the Julia process, such as the optimization level or number of threads, may

--- a/docs/src/juliacall.md
+++ b/docs/src/juliacall.md
@@ -115,25 +115,54 @@ systems that may be readonly. Note that the project set in
 `PYTHON_JULIACALL_PROJECT` *must* already have PythonCall.jl installed and it
 *must* match the JuliaCall version, otherwise loading Julia will fail.
 
-### Baking PythonCall into a system image
+### [Baking PythonCall into a system image](@id baking-sysimage)
 
-For the fastest possible startup you can compile `PythonCall` itself (alongside
-your own packages) into a system image with
-[PackageCompiler.jl](https://github.com/JuliaLang/PackageCompiler.jl), so that
-the `using PythonCall` performed at startup is a memory-map rather than a load.
+The first `import juliacall` in a fresh process is slow - typically 10-20
+seconds in a clean container - because Julia starts, deserialises
+`PythonCall` from cache, and JIT-compiles the bridge's hot paths. Long-
+running processes amortise that cost. Short-lived ones - serverless
+functions, queue workers, CI jobs that start, handle one request, and
+exit - pay it on every invocation.
 
-When `PythonCall` is baked into the system image its `__init__` runs *during*
-`jl_init_with_image`, before juliacall's bootstrap has defined the
-`Main.__PythonCall_libptr` global it normally uses to detect that it is
-embedded. To support this, set the `embedded` preference (or the
-`JULIA_PYTHONCALL_EMBEDDED=yes` environment variable) together with the `lib`
-preference / `JULIA_PYTHONCALL_LIB` pointing at the running interpreter's
-libpython. With `embedded` set, PythonCall takes the embedded path even without
-the global and opens libpython by path (it is already loaded in the process, so
-this is just a handle). The default is `no`, leaving normal behaviour
-unchanged. Use this together with `PYTHON_JULIACALL_SYSIMAGE` (below), and
-`PYTHON_JULIACALL_EXE` / `PYTHON_JULIACALL_PROJECT` so juliacall resolves the
-baked environment directly.
+Compiling `PythonCall` into a system image with
+[PackageCompiler.jl](https://github.com/JuliaLang/PackageCompiler.jl)
+collapses load+compile into a memory-map at startup, typically cutting
+that cost by an order of magnitude. To bake the resulting image so
+`import juliacall` picks it up automatically, set
+`PythonCall._is_embedded[] = true` inside the sysimage-build process.
+
+PackageCompiler's `precompile_execution_file=` is run in a separate child
+process whose state is not snapshotted, so the flag must be set via the
+`script=` keyword instead.
+
+```julia
+# bake_embedded.jl
+PythonCall._is_embedded[] = true
+```
+
+```julia
+using PackageCompiler
+create_sysimage(["PythonCall"];
+    sysimage_path = "myapp.so",
+    script = "bake_embedded.jl",
+    project = ".",
+)
+```
+
+Pass `precompile_execution_file=` alongside `script=` to also bake your own
+hot code paths into the image.
+
+At runtime, point juliacall at the resulting sysimage via
+[`PYTHON_JULIACALL_SYSIMAGE`](@ref julia-config), and set the
+[`lib`](@ref pythoncall-config) preference / `JULIA_PYTHONCALL_LIB` to the
+path of the host's libpython - the embedded path needs an explicit handle
+to libpython since the bridge does not load the interpreter itself.
+
+#### Subprocess behaviour
+
+If a julia process without a running Python interpreter loads a sysimage
+baked with `_is_embedded[] = true` (for example a `Base.compilecache`
+child), `PythonCall` loads as inactive - no error, no Python state.
 
 ## [Configuration](@id julia-config)
 

--- a/src/C/C.jl
+++ b/src/C/C.jl
@@ -19,7 +19,8 @@ if @load_preference("exe", "@CondaPkg") == "@CondaPkg"
 end
 
 import ..PythonCall:
-    python_executable_path, python_library_path, python_library_handle, python_version
+    python_executable_path, python_library_path, python_library_handle, python_version,
+    _is_embedded
 
 include("consts.jl")
 include("pointers.jl")

--- a/src/C/context.jl
+++ b/src/C/context.jl
@@ -105,46 +105,57 @@ on_main_thread
 
 function init_context()
 
-    # Normally PythonCall is embedded when Python (via juliacall) defines the
-    # global `Main.__PythonCall_libptr`, set by juliacall's bootstrap *after*
-    # `jl_init_with_image`. If PythonCall is baked into a juliacall system
-    # image, its `__init__` runs *during* `jl_init_with_image` — before that
-    # global exists — yet we are still embedded (Python is the running host).
-    # The opt-in `embedded` preference / `JULIA_PYTHONCALL_EMBEDDED` forces the
-    # embedded path in that case; libpython is obtained by path since it is
-    # already loaded in this process. Unset, behaviour is unchanged.
+    # Embedded if juliacall set Main.__PythonCall_libptr or the sysimage baked
+    # `_is_embedded[]` to `true`.
     has_libptr = hasproperty(Base.Main, :__PythonCall_libptr)
-    CTX.is_embedded = has_libptr || Utils.getpref_embedded()
+    CTX.is_embedded = has_libptr || _is_embedded[]
 
     if CTX.is_embedded
+        # Locate libpython.
         if has_libptr
-            # In this case, getting a handle to libpython is easy
             CTX.lib_ptr = Base.Main.__PythonCall_libptr::Ptr{Cvoid}
         else
-            # Baked into a sysimage: open libpython by path (the `lib`
-            # preference / JULIA_PYTHONCALL_LIB). dlopen of an
-            # already-loaded library just returns a handle to it.
-            lib_path = something(Utils.getpref_lib(), Some(nothing))
-            lib_path === nothing && error(
-                "JULIA_PYTHONCALL_EMBEDDED is set but libpython is unknown; " *
-                "set the `lib` preference or JULIA_PYTHONCALL_LIB to its path.",
-            )
-            lib_ptr = dlopen_e(lib_path, CTX.dlopen_flags)
-            lib_ptr == C_NULL &&
-                error("Python library $(repr(lib_path)) could not be opened.")
-            CTX.lib_path = lib_path
-            CTX.lib_ptr = lib_ptr
+            lib_path = Utils.getpref_lib()
+            if lib_path !== nothing
+                lib_ptr = dlopen_e(lib_path, CTX.dlopen_flags)
+                if lib_ptr != C_NULL
+                    CTX.lib_path = lib_path
+                    CTX.lib_ptr = lib_ptr
+                end
+            end
         end
-        init_pointers()
-        # Check Python is initialized
-        Py_IsInitialized() == 0 && error("Python is not already initialized.")
-        CTX.is_initialized = true
-        CTX.which = :embedded
-        exe_path = Utils.getpref_exe()
-        if exe_path != ""
-            CTX.exe_path = exe_path
-            # this ensures PyCall uses the same Python interpreter
-            get!(ENV, "PYTHON", exe_path)
+
+        embedded_ok = false
+        if CTX.lib_ptr != C_NULL
+            init_pointers()
+            embedded_ok = Py_IsInitialized() != 0
+        end
+
+        if embedded_ok
+            CTX.is_initialized = true
+            CTX.which = :embedded
+            exe_pref = Utils.getpref_exe()
+            if exe_pref != ""
+                CTX.exe_path = exe_pref
+                get!(ENV, "PYTHON", exe_pref)
+            else
+                exe_path = _embedded_program_path()
+                if exe_path !== nothing
+                    CTX.exe_path = exe_path
+                    get!(ENV, "PYTHON", exe_path)
+                end
+            end
+        elseif has_libptr
+            error("PythonCall is in embedded mode but no Python interpreter is running in this process.")
+        else
+            # Either the `lib` preference is unset, or Python is not running
+            # in this process (e.g. a julia.exe child of `Base.compilecache`
+            # loaded a sysimage baked for the embedded path). Leave PythonCall
+            # inactive instead of erroring.
+            CTX.is_embedded = false
+            CTX.lib_ptr = C_NULL
+            CTX.lib_path = missing
+            return
         end
     else
         # Find Python executable
@@ -345,6 +356,46 @@ function init_context()
     @debug "Initialized PythonCall.jl" CTX.is_embedded CTX.is_initialized CTX.exe_path CTX.lib_path CTX.lib_ptr CTX.pyprogname CTX.pyhome CTX.version CTX.is_free_threaded
 
     return
+end
+
+# Return `sys.executable` as a String, or nothing. Requires init_pointers().
+function _embedded_program_path()
+    import_mod = dlsym_e(CTX.lib_ptr, :PyImport_ImportModule)
+    getattr    = dlsym_e(CTX.lib_ptr, :PyObject_GetAttrString)
+    asutf8     = dlsym_e(CTX.lib_ptr, :PyUnicode_AsUTF8AndSize)
+    decref     = dlsym_e(CTX.lib_ptr, :Py_DecRef)
+    errclear   = dlsym_e(CTX.lib_ptr, :PyErr_Clear)
+    (import_mod == C_NULL || getattr == C_NULL || asutf8 == C_NULL ||
+        decref == C_NULL || errclear == C_NULL) && return nothing
+
+    sys_mod = ccall(import_mod, Ptr{Cvoid}, (Ptr{Cchar},), "sys")
+    if sys_mod == C_NULL
+        ccall(errclear, Cvoid, ())
+        return nothing
+    end
+    result = nothing
+    try
+        exec_obj = ccall(getattr, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cchar}), sys_mod, "executable")
+        if exec_obj == C_NULL
+            ccall(errclear, Cvoid, ())
+            return nothing
+        end
+        try
+            size_ref = Ref{Cssize_t}(0)
+            cstr = ccall(asutf8, Ptr{Cchar}, (Ptr{Cvoid}, Ref{Cssize_t}), exec_obj, size_ref)
+            if cstr == C_NULL
+                ccall(errclear, Cvoid, ())
+                return nothing
+            end
+            size_ref[] == 0 && return nothing
+            result = unsafe_string(cstr, size_ref[])
+        finally
+            ccall(decref, Cvoid, (Ptr{Cvoid},), exec_obj)
+        end
+    finally
+        ccall(decref, Cvoid, (Ptr{Cvoid},), sys_mod)
+    end
+    return result
 end
 
 function Base.show(io::IO, ::MIME"text/plain", ctx::Context)

--- a/src/C/context.jl
+++ b/src/C/context.jl
@@ -105,11 +105,36 @@ on_main_thread
 
 function init_context()
 
-    CTX.is_embedded = hasproperty(Base.Main, :__PythonCall_libptr)
+    # Normally PythonCall is embedded when Python (via juliacall) defines the
+    # global `Main.__PythonCall_libptr`, set by juliacall's bootstrap *after*
+    # `jl_init_with_image`. If PythonCall is baked into a juliacall system
+    # image, its `__init__` runs *during* `jl_init_with_image` — before that
+    # global exists — yet we are still embedded (Python is the running host).
+    # The opt-in `embedded` preference / `JULIA_PYTHONCALL_EMBEDDED` forces the
+    # embedded path in that case; libpython is obtained by path since it is
+    # already loaded in this process. Unset, behaviour is unchanged.
+    has_libptr = hasproperty(Base.Main, :__PythonCall_libptr)
+    CTX.is_embedded = has_libptr || Utils.getpref_embedded()
 
     if CTX.is_embedded
-        # In this case, getting a handle to libpython is easy
-        CTX.lib_ptr = Base.Main.__PythonCall_libptr::Ptr{Cvoid}
+        if has_libptr
+            # In this case, getting a handle to libpython is easy
+            CTX.lib_ptr = Base.Main.__PythonCall_libptr::Ptr{Cvoid}
+        else
+            # Baked into a sysimage: open libpython by path (the `lib`
+            # preference / JULIA_PYTHONCALL_LIB). dlopen of an
+            # already-loaded library just returns a handle to it.
+            lib_path = something(Utils.getpref_lib(), Some(nothing))
+            lib_path === nothing && error(
+                "JULIA_PYTHONCALL_EMBEDDED is set but libpython is unknown; " *
+                "set the `lib` preference or JULIA_PYTHONCALL_LIB to its path.",
+            )
+            lib_ptr = dlopen_e(lib_path, CTX.dlopen_flags)
+            lib_ptr == C_NULL &&
+                error("Python library $(repr(lib_path)) could not be opened.")
+            CTX.lib_path = lib_path
+            CTX.lib_ptr = lib_ptr
+        end
         init_pointers()
         # Check Python is initialized
         Py_IsInitialized() == 0 && error("Python is not already initialized.")

--- a/src/Compat/Compat.jl
+++ b/src/Compat/Compat.jl
@@ -23,6 +23,7 @@ include("serialization.jl")
 include("tables.jl")
 
 function __init__()
+    C.CTX.is_initialized || return
     init_gui()
     init_pyshow()
 end

--- a/src/Convert/Convert.jl
+++ b/src/Convert/Convert.jl
@@ -36,6 +36,7 @@ include("numpy.jl")
 include("pandas.jl")
 
 function __init__()
+    C.CTX.is_initialized || return
     init_pyconvert()
     init_ctypes()
     init_numpy()

--- a/src/Core/Core.jl
+++ b/src/Core/Core.jl
@@ -209,6 +209,9 @@ include("juliacall.jl")
 include("pyconst_macro.jl")
 
 function __init__()
+    # Skip if C bailed out (e.g. a julia.exe child of Base.compilecache
+    # loaded a sysimage baked for the embedded path).
+    C.CTX.is_initialized || return
     init_consts()
     init_datetime()
     init_stdlib()

--- a/src/JlWrap/C.jl
+++ b/src/JlWrap/C.jl
@@ -364,6 +364,7 @@ function init_c()
 end
 
 function __init__()
+    C.CTX.is_initialized || return
     init_c()
 end
 

--- a/src/JlWrap/JlWrap.jl
+++ b/src/JlWrap/JlWrap.jl
@@ -51,6 +51,7 @@ include("set.jl")
 include("callback.jl")
 
 function __init__()
+    C.CTX.is_initialized || return
     init_base()
     init_raw()
     init_any()

--- a/src/PythonCall.jl
+++ b/src/PythonCall.jl
@@ -2,6 +2,14 @@ module PythonCall
 
 const ROOT_DIR = dirname(@__DIR__)
 
+"""
+    PythonCall._is_embedded
+
+Marks the running sysimage as embedded in a Python host. Set to `true` in a
+PackageCompiler `script=` to bake the embedded path into the sysimage.
+"""
+const _is_embedded = Ref(false)
+
 include("API/API.jl")
 include("Utils/Utils.jl")
 include("NumpyDates/NumpyDates.jl")

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -17,7 +17,6 @@ checkpref(::Type{String}, x::AbstractString) = convert(String, x)
 getpref_exe() = getpref(String, "exe", "JULIA_PYTHONCALL_EXE", "")
 getpref_lib() = getpref(String, "lib", "JULIA_PYTHONCALL_LIB", nothing)
 getpref_pickle() = getpref(String, "pickle", "JULIA_PYTHONCALL_PICKLE", "pickle")
-getpref_embedded() = getpref(String, "embedded", "JULIA_PYTHONCALL_EMBEDDED", "no") == "yes"
 
 function explode_union(T)
     @nospecialize T

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -17,6 +17,7 @@ checkpref(::Type{String}, x::AbstractString) = convert(String, x)
 getpref_exe() = getpref(String, "exe", "JULIA_PYTHONCALL_EXE", "")
 getpref_lib() = getpref(String, "lib", "JULIA_PYTHONCALL_LIB", nothing)
 getpref_pickle() = getpref(String, "pickle", "JULIA_PYTHONCALL_PICKLE", "pickle")
+getpref_embedded() = getpref(String, "embedded", "JULIA_PYTHONCALL_EMBEDDED", "no") == "yes"
 
 function explode_union(T)
     @nospecialize T

--- a/src/Wrap/Wrap.jl
+++ b/src/Wrap/Wrap.jl
@@ -32,6 +32,7 @@ include("PyTable.jl")
 include("PyPandasDataFrame.jl")
 
 function __init__()
+    C.CTX.is_initialized || return
     priority = PYCONVERT_PRIORITY_ARRAY
     pyconvert_add_rule("<arraystruct>", PyArray, pyconvert_rule_array_nocopy, priority)
     pyconvert_add_rule("<arrayinterface>", PyArray, pyconvert_rule_array_nocopy, priority)


### PR DESCRIPTION
## Summary

Lets `PythonCall` itself be compiled into a juliacall system image (opt-in). With it baked in, the `using PythonCall` that `import juliacall` performs becomes a memory-map instead of a multi-second load+compile. In a containerised juliacall workload we measured, fresh-process startup drops from ~18 s to ~1.9 s. Off by default - no behaviour change unless enabled. It's meant as a low-risk interim until the automatic fix discussed in #436 (or related work) lands; it doesn't conflict with or preclude that.

## Motivation

In short-lived Python processes that embed Julia via juliacall - serverless or autoscaled containers (AWS Lambda, queue workers, CI jobs) that start, handle one request, and exit - there's no long-lived process to amortise Julia start-up. Every cold start pays it again, and the dominant part is the `using PythonCall` that `import juliacall` runs to bring the bridge up.

Measured, fresh container to first call:

|                                              | container init |
|----------------------------------------------|----------------|
| stock juliacall (only app packages baked)    | ~18 s          |
| `PythonCall` also baked into the sysimage    | ~1.9 s         |

`PYTHON_JULIACALL_SYSIMAGE` already exists, but a sysimage with only the application packages still runs `using PythonCall` every cold start. Baking `PythonCall` in too is the fix, but it currently fails: when `PythonCall` is in the sysimage its `__init__` runs during `jl_init_with_image`, before juliacall's bootstrap has set `Main.__PythonCall_libptr`. `init_context()` decides "embedded" only from that global, so it sees "not embedded"; since Python is mid-`import juliacall`, `init_juliacall()` then errors with `'juliacall' module already exists`.

## Change

Add one module-level flag, `PythonCall._is_embedded`, that the user flips inside a PackageCompiler `script=` to mark the resulting sysimage as embedded. At runtime, `PythonCall.__init__` reads the flag and takes the embedded path; libpython is opened from the existing `lib` preference / `JULIA_PYTHONCALL_LIB`. If the sysimage is loaded by a julia process with no running Python (e.g. a `Base.compilecache` child), the embedded path rolls back and PythonCall stays inactive instead of erroring. Docs include a worked PackageCompiler example.

## Backward compatibility

Backwards compatible since the flag is off by default. The classic juliacall path and the non-embedded path are unchanged; `lib` and `exe` preferences keep their existing semantics. No new preferences or environment variables are introduced.

## Testing

The new code path only runs when explicitly enabled, so default behaviour is unchanged and the existing test suites are unaffected.

Verified manually on Linux (AWS Lambda base image `public.ecr.aws/lambda/python:3.12`) and Windows (desktop, Python 3.13). A plain `julia.exe --sysimage=` load of a baked sysimage leaves PythonCall inactive without erroring. Not tested on macOS. No automated test is included because exercising it requires building a system image in CI, which is slow - happy to add one, or document the steps, if you'd prefer.

## Related issues

Relates to #436 and #600 - this unblocks their use case (baking PythonCall into a custom system image) as an interim. The root-cause fix described in #436 - resetting PythonCall's sysimage-persisted state in `__init__` so it works with no opt-in - is the longer-term path; this PR doesn't attempt or preclude it.

Also relevant to #762 ("Improve juliacall startup time?", which explicitly asks about compiling a system image) and a building block for #76 ("Compile and use custom sysimages automatically"). Does not address #129 (a different failure: `no environment in the LOAD_PATH depends on CondaPkg`).
