### PR TITLE
juliacall: optionally supply libjulia path/bindir to skip the discovery subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+* JuliaCall: added `libpath` / `default_bindir` options
+  (`PYTHON_JULIACALL_LIBPATH` / `PYTHON_JULIACALL_DEFAULT_BINDIR`) to supply
+  libjulia's path and `Sys.BINDIR` directly, skipping the discovery subprocess
+  at startup. Behaviour is unchanged unless both are set.
+
 ## 0.9.34 (2026-05-18)
 * Bug fixes.
 

--- a/docs/src/juliacall.md
+++ b/docs/src/juliacall.md
@@ -142,6 +142,8 @@ be configured in two ways:
 | `-X juliacall-heap-size-hint=<N>` | `PYTHON_JULIACALL_HEAP_SIZE_HINT=<N>` | Hint for initial heap size in bytes. |
 | `-X juliacall-exe=<file>` | `PYTHON_JULIACALL_EXE=<file>` | Path to Julia binary to use (overrides JuliaPkg). |
 | `-X juliacall-project=<dir>` | `PYTHON_JULIACALL_PROJECT=<dir>` | Path to the Julia project to use (overrides JuliaPkg). |
+| `-X juliacall-libpath=<file>` | `PYTHON_JULIACALL_LIBPATH=<file>` | Path to libjulia. If set together with `default-bindir`, skips the subprocess that discovers it. |
+| `-X juliacall-default-bindir=<dir>` | `PYTHON_JULIACALL_DEFAULT_BINDIR=<dir>` | Julia's `Sys.BINDIR`. If set together with `libpath`, skips the subprocess that discovers it. |
 | `-X juliacall-trace-compile=<stderr\|name>` | `PYTHON_JULIACALL_TRACE_COMPILE=<stderr\|name>` | Print precompile statements. |
 | `-X juliacall-trace-compile-timing` | `PYTHON_JULIACALL_TRACE_COMPILE_TIMING=<yes\|no>` | Include timings with precompile statements. |
 

--- a/pysrc/juliacall/__init__.py
+++ b/pysrc/juliacall/__init__.py
@@ -205,10 +205,19 @@ def init():
     exepath = CONFIG['exepath']
     project = CONFIG['project']
 
-    # Find the Julia library
-    cmd = [exepath, '--project='+project, '--startup-file=no', '-O0', '--compile=min',
-           '-e', 'import Libdl; print(abspath(Libdl.dlpath("libjulia")), "\\0", Sys.BINDIR)']
-    libpath, default_bindir = subprocess.run(cmd, check=True, capture_output=True, encoding='utf8').stdout.split('\0')
+    # Find the Julia library.
+    #
+    # This normally starts a short-lived Julia process just to print libjulia's
+    # path and Sys.BINDIR. In deployment scenarios (e.g. a pre-built container
+    # or system image) these are static and known ahead of time, so they may be
+    # supplied directly via the `libpath` / `default_bindir` options to skip the
+    # extra process. Behaviour is unchanged unless both are set.
+    libpath = path_option('libpath', check_exists=True)[0]
+    default_bindir = path_option('default_bindir', check_exists=True)[0]
+    if libpath is None or default_bindir is None:
+        cmd = [exepath, '--project='+project, '--startup-file=no', '-O0', '--compile=min',
+               '-e', 'import Libdl; print(abspath(Libdl.dlpath("libjulia")), "\\0", Sys.BINDIR)']
+        libpath, default_bindir = subprocess.run(cmd, check=True, capture_output=True, encoding='utf8').stdout.split('\0')
     assert os.path.exists(libpath)
     assert os.path.exists(default_bindir)
     CONFIG['libpath'] = libpath


### PR DESCRIPTION
## Summary

Adds **opt-in** `libpath` / `default_bindir` juliacall options so the path to libjulia and `Sys.BINDIR` can be supplied directly, skipping the short-lived Julia process `init()` otherwise spawns at startup just to discover them. No behaviour change unless both are set.

## Motivation

In **short-lived Python processes that embed Julia via juliacall** (serverless / autoscaled containers), every fresh process pays `import juliacall` startup with no long-lived server to amortise it. During that startup `init()` launches a whole separate Julia process — `julia -O0 --compile=min -e 'print(Libdl.dlpath("libjulia"), Sys.BINDIR)'` — solely to discover two strings. That is an entire extra Julia interpreter boot on the critical path of *every cold start*. In a pre-built container or system image those paths are static and known at build time, so the subprocess is pure repeated waste.

## Change

Two new juliacall options (same `-X` / `PYTHON_JULIACALL_*` mechanism as the rest):

- `libpath` → `PYTHON_JULIACALL_LIBPATH`
- `default_bindir` → `PYTHON_JULIACALL_DEFAULT_BINDIR`

When **both** are set the discovery subprocess is skipped and the supplied values used; otherwise behaviour is exactly as before. `docs/src/juliacall.md` config table and `CHANGELOG.md` updated.

## Backward compatibility

No behaviour change unless both options are set. Values are validated with the existing `path_option(..., check_exists=True)` helper, so a bad path fails fast with the standard error message.

## Testing

The new options only take effect when explicitly set, so default behaviour is unchanged and the existing test suites are unaffected.

Independent of, and complementary to, the system-image PR (#773): together they remove the two biggest fixed costs from a cold juliacall start — loading `PythonCall`, and this extra Julia process.

## Related issues

Relates to #762 ("Improve juliacall startup time?") — this removes a whole extra Julia process from every cold start. Adjacent to #619 (offline / `BINDIR` startup); note #619's specific complaint (juliapkg still attempting a network install) is a different concern this PR does not by itself resolve.

