### PR TITLE
Fix conda installation command for pyjuliacall

### DIFF
--- a/docs/src/juliacall.md
+++ b/docs/src/juliacall.md
@@ -9,7 +9,7 @@ pip install juliacall
 
 If you prefer Conda, there is a community effort to also release this on conda-forge:
 ```bash
-conda install conda-forge::pyjuliapkg
+conda install conda-forge::pyjuliacall
 ```
 
 Developers may wish to clone the repo (https://github.com/JuliaPy/PythonCall.jl) directly


### PR DESCRIPTION
The pyjuliacall conda package was split out from the pyjuliapkg conda package (and depends on it).